### PR TITLE
Add repro for $select parsing bug on dotted identifiers

### DIFF
--- a/SelectTokenizeBug/Repro.cs
+++ b/SelectTokenizeBug/Repro.cs
@@ -1,0 +1,69 @@
+using Microsoft.AspNet.OData;
+using Microsoft.AspNet.OData.Builder;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNet.OData.Query;
+using Microsoft.OData;
+using Microsoft.OData.Edm;
+using Microsoft.OData.UriParser;
+using System.ComponentModel.DataAnnotations;
+using System.Net.Http;
+using System.Web.Http;
+using Xunit;
+using ODataRoutingPath = Microsoft.AspNet.OData.Routing.ODataPath;
+
+namespace SelectTokenizeBug
+{
+    public class Doc
+    {
+        [Key]
+        public string Id { get; set; }
+
+        public int Rating { get; set; }
+    }
+
+    public class SelectReproTests
+    {
+        private static ODataQueryOptions CreateQueryOptions(string queryString)
+        {
+            const string DocsEntitySetName = "Docs";
+
+            var builder = new ODataConventionModelBuilder();
+            builder.EntitySet<Doc>(DocsEntitySetName);
+            var model = builder.GetEdmModel();
+
+            var config = new HttpConfiguration();
+            config.EnableDependencyInjection();
+            config.MapODataServiceRoute("odata", null, model);
+
+            var request = new HttpRequestMessage(HttpMethod.Get, $"http://localhost/{DocsEntitySetName}?{queryString}");
+            request.SetConfiguration(config);
+
+            var path = new ODataRoutingPath(new EntitySetSegment(model.FindDeclaredEntitySet(DocsEntitySetName)));
+            var context = new ODataQueryContext(model, typeof(Doc), path);
+            return new ODataQueryOptions(context, request);
+        }
+
+        [Fact]
+        public void SelectWithSystemTokenThrowsODataException()
+        {
+            ODataQueryOptions queryOptions = CreateQueryOptions("$select=Rating,$count");
+            var e = Assert.Throws<ODataException>(() => queryOptions.SelectExpand.SelectExpandClause);
+            Assert.Equal("Found system token '$count' in select or expand clause 'Rating,$count'.", e.Message);
+        }
+
+        [Fact]
+        public void SelectWithDottedNameThrowsODataException()
+        {
+            ODataQueryOptions queryOptions = CreateQueryOptions("$select=Rating,Dotted.Name");
+            var e = Assert.Throws<ODataException>(() => queryOptions.SelectExpand.SelectExpandClause);
+
+            // This error message doesn't exist in the OData libraries. Consider it a suggestion for what the
+            // error message should be.
+            const string ExpectedMessage =
+                "Found invalid identifier 'Dotted.Name' in $select. If this is the name of a property of a complex type, make sure to " +
+                "use slash (/) as the separator instead of dot (.).";
+
+            Assert.Equal(ExpectedMessage, e.Message);
+        }
+    }
+}

--- a/SelectTokenizeBug/SelectTokenizeBug.csproj
+++ b/SelectTokenizeBug/SelectTokenizeBug.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net462</TargetFramework>
+    <Platforms>AnyCPU;x64</Platforms>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNet.OData" Version="7.1.0" />
+    <PackageReference Include="Microsoft.OData.Core" Version="7.5.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+  </ItemGroup>
+
+</Project>

--- a/SelectTokenizeBug/SelectTokenizeBug.sln
+++ b/SelectTokenizeBug/SelectTokenizeBug.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29102.190
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SelectTokenizeBug", "SelectTokenizeBug.csproj", "{D9F477FC-4B95-4C04-B6AB-D87404DF9847}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D9F477FC-4B95-4C04-B6AB-D87404DF9847}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9F477FC-4B95-4C04-B6AB-D87404DF9847}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D9F477FC-4B95-4C04-B6AB-D87404DF9847}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D9F477FC-4B95-4C04-B6AB-D87404DF9847}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0134BE6A-6944-475F-8612-33C91F76D87F}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Parsing a $select clause with a dotted name that doesn't correspond to any
known type name ought to throw ODataException, but instead it returns an
empty path segment.